### PR TITLE
chore: update `.swift-format` to 601.0.0's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: swift:6.0
+    container: swift:6.1
     steps:
       - uses: actions/checkout@v4
       - run: swift format lint -rsp .

--- a/.swift-format
+++ b/.swift-format
@@ -69,7 +69,7 @@
     "UseSingleLinePropertyGetter" : true,
     "UseSynthesizedInitializer" : true,
     "UseTripleSlashForDocumentationComments" : true,
-    "UseWhereClausesInForLoops" : false,
+    "UseWhereClausesInForLoops" : true,
     "ValidateDocumentationComments" : true
   },
   "spacesAroundRangeFormationOperators" : false,

--- a/.swift-format
+++ b/.swift-format
@@ -11,6 +11,7 @@
   "lineBreakBeforeControlFlowKeywords" : false,
   "lineBreakBeforeEachArgument" : true,
   "lineBreakBeforeEachGenericRequirement" : true,
+  "lineBreakBetweenDeclarationAttributes" : false,
   "lineLength" : 120,
   "maximumBlankLines" : 1,
   "multiElementCollectionTrailingCommas" : true,
@@ -20,12 +21,18 @@
     ]
   },
   "prioritizeKeepingFunctionOutputTogether" : true,
+  "reflowMultilineStringLiterals" : {
+    "never" : {
+
+    }
+  },
   "respectsExistingLineBreaks" : true,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : true,
     "AlwaysUseLiteralForEmptyCollectionInit" : true,
     "AlwaysUseLowerCamelCase" : true,
     "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
     "BeginDocumentationCommentWithOneLineSummary" : true,
     "DoNotUseSemicolons" : true,
     "DontRepeatTypeInStaticProperties" : true,
@@ -40,6 +47,7 @@
     "NoAssignmentInExpressions" : true,
     "NoBlockComments" : true,
     "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : true,
     "NoEmptyTrailingClosureParentheses" : true,
     "NoLabelsInCasePatterns" : true,
     "NoLeadingUnderscores" : false,
@@ -65,6 +73,7 @@
     "ValidateDocumentationComments" : true
   },
   "spacesAroundRangeFormationOperators" : false,
+  "spacesBeforeEndOfLineComments" : 2,
   "tabWidth" : 4,
   "version" : 1
 }


### PR DESCRIPTION
Some new rules have been added in swift-format 601.0.0.